### PR TITLE
Automation Control Center: health monitoring and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,98 @@ Service for managing nginx configurations dynamically.
 
 Each component maintains its own build configuration and can be developed independently while being part of the unified repository structure.
 
+## Automation Control Center
+
+The Control Center adds operational monitoring on top of the existing automation
+list: health status per automation, manual health checks, a health summary, and
+a diagnostics view with recent check history.
+
+### What was added
+
+Backend (`/backend`):
+
+- `internal/infra/database.go` — the operational models (health events,
+  dependencies, route checks, alerts, incidents, SLOs) are now part of
+  `AutoMigrate`, and the `uuid-ossp` extension is ensured on startup.
+- `internal/router/routes.go` — three routes registered:
+  - `GET  /api/v1/automation/health/summary`
+  - `POST /api/v1/automation/:id/health-check`
+  - `GET  /api/v1/automation/:id/diagnostics`
+- `internal/automation/automation_service.go` — each health check now persists
+  an `AutomationHealthEvent` (history) and the diagnostics response returns the
+  last 10 events plus the last checked/success/failure timestamps. The health
+  summary now reports `total`, `healthy`, `warning`, `degraded`, `broken` and
+  `unknown` counts.
+- `internal/automation/automation_repository.go` — `SaveHealthEvent` and
+  `FindHealthEvents` for persisting and reading health history.
+
+Frontend (`/frontend`):
+
+- `services/automations/automations.service.ts` — `getHealthSummary`,
+  `runHealthCheck` and `getDiagnostics` methods.
+- `pages/control-center/` — the Control Center page (summary bar, automation
+  table with status badges, last checked/success/failure, failure reason, a
+  manual **Run Check** button, an **Open** link for browser-safe URLs, and a
+  **Diagnostics** modal with configuration checks and recent health events).
+- A **Control Center** entry was added to the home menu, routed at
+  `/control-center`.
+
+### Health check behaviour
+
+- `http` (default): GETs the health check URL (or `http://host:port`) and
+  compares against the expected status code.
+- `tcp`: dials `host:port`.
+- `manual` / `disabled`: reported as `unknown`, no automatic probe.
+
+Repeated failures escalate the status: `warning` → `degraded` → `broken`.
+
+### Safety
+
+No arbitrary command execution is performed. Health checks are HTTP/TCP probes
+only, and opening a target uses a browser `window.open` with `noopener`. Local
+runner / service control remains out of scope (see the blueprint, step 10).
+
+### How to test
+
+Backend compiles:
+
+```bash
+cd backend
+go build ./...
+```
+
+Frontend compiles:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+Full stack (optional, end-to-end):
+
+```bash
+docker-compose up --build
+```
+
+Then open the gateway, log in, and choose **Control Center** from the home
+menu. Use **Run Check** on a row to probe an automation; the status badge,
+timestamps and summary bar update, and **Diagnostics** shows the recorded
+history.
+
+API smoke test (with the backend running):
+
+```bash
+# health summary
+curl http://localhost/api/v1/automation/health/summary
+
+# run a health check for one automation
+curl -X POST http://localhost/api/v1/automation/<automation-id>/health-check
+
+# diagnostics for one automation
+curl http://localhost/api/v1/automation/<automation-id>/diagnostics
+```
+
 ## License
 
 See LICENSE file for details.

--- a/backend/internal/automation/automation_repository.go
+++ b/backend/internal/automation/automation_repository.go
@@ -18,6 +18,8 @@ type Repository interface {
 	MaxPosition() (int, error)
 	GetByURLPath(urlPath string) (*models.Automation, error)
 	Transaction(txFunc func(tx *gorm.DB) error) (err error)
+	SaveHealthEvent(event *models.AutomationHealthEvent) error
+	FindHealthEvents(automationID uuid.UUID, limit int) ([]models.AutomationHealthEvent, error)
 }
 
 type GormUserRepository struct {
@@ -111,6 +113,26 @@ func (r *GormUserRepository) MaxPosition() (int, error) {
 		return 0, err
 	}
 	return automation.Position, nil
+}
+
+func (r *GormUserRepository) SaveHealthEvent(event *models.AutomationHealthEvent) error {
+	return r.DB.Create(event).Error
+}
+
+func (r *GormUserRepository) FindHealthEvents(automationID uuid.UUID, limit int) ([]models.AutomationHealthEvent, error) {
+	var events []models.AutomationHealthEvent
+	if limit <= 0 {
+		limit = 20
+	}
+	err := r.DB.
+		Where("automation_id = ?", automationID).
+		Order("checked_at desc").
+		Limit(limit).
+		Find(&events).Error
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
 }
 
 func (r *GormUserRepository) GetByURLPath(urlPath string) (*models.Automation, error) {

--- a/backend/internal/automation/automation_service.go
+++ b/backend/internal/automation/automation_service.go
@@ -31,10 +31,12 @@ type HealthResult struct {
 }
 
 type HealthSummary struct {
-	Healthy  int       `json:"healthy"`
-	Warning  int       `json:"warning"`
-	Broken   int       `json:"broken"`
-	Unknown  int       `json:"unknown"`
+	Total     int       `json:"total"`
+	Healthy   int       `json:"healthy"`
+	Warning   int       `json:"warning"`
+	Degraded  int       `json:"degraded"`
+	Broken    int       `json:"broken"`
+	Unknown   int       `json:"unknown"`
 	CheckedAt time.Time `json:"checkedAt"`
 }
 
@@ -46,15 +48,20 @@ type LaunchResult struct {
 }
 
 type DiagnosticResult struct {
-	AutomationID      uuid.UUID         `json:"automationId"`
-	Name              string            `json:"name"`
-	Status            string            `json:"status"`
-	LaunchTarget      string            `json:"launchTarget"`
-	HealthCheckTarget string            `json:"healthCheckTarget"`
-	RoutePath         string            `json:"routePath"`
-	Host              string            `json:"host"`
-	Port              int               `json:"port"`
-	Checks            map[string]string `json:"checks"`
+	AutomationID      uuid.UUID                      `json:"automationId"`
+	Name              string                         `json:"name"`
+	Status            string                         `json:"status"`
+	LaunchTarget      string                         `json:"launchTarget"`
+	HealthCheckTarget string                         `json:"healthCheckTarget"`
+	RoutePath         string                         `json:"routePath"`
+	Host              string                         `json:"host"`
+	Port              int                            `json:"port"`
+	LastCheckedAt     *time.Time                     `json:"lastCheckedAt,omitempty"`
+	LastSuccessAt     *time.Time                     `json:"lastSuccessAt,omitempty"`
+	LastFailureAt     *time.Time                     `json:"lastFailureAt,omitempty"`
+	LastFailureReason string                         `json:"lastFailureReason,omitempty"`
+	Checks            map[string]string              `json:"checks"`
+	RecentEvents      []models.AutomationHealthEvent `json:"recentEvents"`
 }
 
 type Service interface {
@@ -279,12 +286,14 @@ func (s *service) RunHealthCheck(id uuid.UUID) (*HealthResult, error) {
 	started := time.Now().UTC()
 	status := "healthy"
 	failureReason := ""
+	target := ""
 
 	s.applyAutomationDefaults(automation)
 
-	switch strings.ToLower(automation.HealthCheckType) {
+	checkType := strings.ToLower(automation.HealthCheckType)
+	switch checkType {
 	case "tcp":
-		target := fmt.Sprintf("%s:%d", automation.Host, automation.Port)
+		target = fmt.Sprintf("%s:%d", automation.Host, automation.Port)
 		conn, errDial := net.DialTimeout("tcp", target, 5*time.Second)
 		if errDial != nil {
 			status = classifyFailure(automation.ConsecutiveFailures + 1)
@@ -296,7 +305,7 @@ func (s *service) RunHealthCheck(id uuid.UUID) (*HealthResult, error) {
 		status = "unknown"
 		failureReason = "automatic health checks are disabled for this automation"
 	default:
-		target := automation.HealthCheckURL
+		target = automation.HealthCheckURL
 		if target == "" {
 			target = fmt.Sprintf("http://%s:%d", automation.Host, automation.Port)
 		}
@@ -339,6 +348,22 @@ func (s *service) RunHealthCheck(id uuid.UUID) (*HealthResult, error) {
 		return nil, errUpdate
 	}
 
+	// Persist the check as a health-history event. A history write failure
+	// must not fail the check itself, so it is only logged.
+	event := &models.AutomationHealthEvent{
+		AutomationID:        automation.ID,
+		Status:              status,
+		CheckType:           checkType,
+		Target:              target,
+		LatencyMs:           latency,
+		FailureReason:       failureReason,
+		ConsecutiveFailures: automation.ConsecutiveFailures,
+		CheckedAt:           checkedAt,
+	}
+	if errEvent := s.repo.SaveHealthEvent(event); errEvent != nil {
+		log.Printf("Failed to persist health event for automation %s: %v", automation.ID, errEvent)
+	}
+
 	return &HealthResult{
 		AutomationID:        automation.ID,
 		Status:              status,
@@ -355,12 +380,15 @@ func (s *service) HealthSummary() (*HealthSummary, error) {
 		return nil, err
 	}
 	summary := &HealthSummary{CheckedAt: time.Now().UTC()}
+	summary.Total = len(automations)
 	for _, automation := range automations {
 		switch strings.ToLower(automation.Status) {
 		case "healthy":
 			summary.Healthy++
-		case "warning", "degraded":
+		case "warning":
 			summary.Warning++
+		case "degraded":
+			summary.Degraded++
 		case "broken":
 			summary.Broken++
 		default:
@@ -403,6 +431,12 @@ func (s *service) Diagnostics(id uuid.UUID) (*DiagnosticResult, error) {
 		"portConfigured":         boolStatus(automation.Port > 0 && automation.Port <= 65535),
 		"dependencyNotesPresent": boolStatus(automation.DependencyNotes != ""),
 	}
+	recentEvents, errEvents := s.repo.FindHealthEvents(automation.ID, 10)
+	if errEvents != nil {
+		log.Printf("Failed to load health history for automation %s: %v", automation.ID, errEvents)
+		recentEvents = []models.AutomationHealthEvent{}
+	}
+
 	return &DiagnosticResult{
 		AutomationID:      automation.ID,
 		Name:              automation.Name,
@@ -412,7 +446,12 @@ func (s *service) Diagnostics(id uuid.UUID) (*DiagnosticResult, error) {
 		RoutePath:         firstNonEmpty(automation.RoutePath, automation.URLPath),
 		Host:              automation.Host,
 		Port:              automation.Port,
+		LastCheckedAt:     automation.LastCheckedAt,
+		LastSuccessAt:     automation.LastSuccessAt,
+		LastFailureAt:     automation.LastFailureAt,
+		LastFailureReason: automation.LastFailureReason,
 		Checks:            checks,
+		RecentEvents:      recentEvents,
 	}, nil
 }
 

--- a/backend/internal/infra/database.go
+++ b/backend/internal/infra/database.go
@@ -35,7 +35,19 @@ func GetDefaultDB() (*gorm.DB, error) {
 }
 
 func RunMigrations(db *gorm.DB) error {
-	if err := db.AutoMigrate(&models.Automation{}); err != nil {
+	// uuid_generate_v4() is used as the default for primary keys.
+	if err := db.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`).Error; err != nil {
+		return err
+	}
+	if err := db.AutoMigrate(
+		&models.Automation{},
+		&models.AutomationHealthEvent{},
+		&models.AutomationDependency{},
+		&models.AutomationRouteCheck{},
+		&models.AutomationAlert{},
+		&models.AutomationIncident{},
+		&models.AutomationSLO{},
+	); err != nil {
 		return err
 	}
 	return nil

--- a/backend/internal/router/routes.go
+++ b/backend/internal/router/routes.go
@@ -29,7 +29,10 @@ func initializeAutomationsRoutes(apiVersion *gin.RouterGroup, autoHandler *autom
 	{
 		automations.GET("/swap/:id1/:id2", autoHandler.SwapPosition)
 		automations.GET("/", autoHandler.GetAll)
+		automations.GET("/health/summary", autoHandler.HealthSummary)
 		automations.GET("/:id", autoHandler.GetByID)
+		automations.POST("/:id/health-check", autoHandler.HealthCheck)
+		automations.GET("/:id/diagnostics", autoHandler.Diagnostics)
 		automations.POST("/", autoHandler.Create)
 		automations.PATCH("/", autoHandler.Update)
 		automations.DELETE("/:id", autoHandler.DeleteByID)

--- a/backend/internal/router/routes_smoke_test.go
+++ b/backend/internal/router/routes_smoke_test.go
@@ -1,0 +1,60 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Mirrors the exact path set registered in initializeAutomationsRoutes to
+// confirm gin builds the route tree without panicking (static + param at the
+// same level) and resolves each new endpoint to the right handler.
+func TestAutomationRoutesNoConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	hit := ""
+	mark := func(name string) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			hit = name
+			c.Status(http.StatusOK)
+		}
+	}
+
+	a := r.Group("/api/v1").Group("/automation")
+	a.GET("/swap/:id1/:id2", mark("swap"))
+	a.GET("/", mark("getAll"))
+	a.GET("/health/summary", mark("summary"))
+	a.GET("/:id", mark("getByID"))
+	a.POST("/:id/health-check", mark("healthCheck"))
+	a.GET("/:id/diagnostics", mark("diagnostics"))
+	a.POST("/", mark("create"))
+	a.PATCH("/", mark("update"))
+	a.DELETE("/:id", mark("delete"))
+	a.GET("/images/:imageName", mark("image"))
+
+	cases := []struct {
+		method, path, want string
+	}{
+		{"GET", "/api/v1/automation/health/summary", "summary"},
+		{"POST", "/api/v1/automation/abc/health-check", "healthCheck"},
+		{"GET", "/api/v1/automation/abc/diagnostics", "diagnostics"},
+		{"GET", "/api/v1/automation/abc", "getByID"},
+		{"GET", "/api/v1/automation/images/logo.png", "image"},
+		{"GET", "/api/v1/automation/swap/1/2", "swap"},
+	}
+	for _, tc := range cases {
+		hit = ""
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s %s -> code %d, want 200", tc.method, tc.path, w.Code)
+		}
+		if hit != tc.want {
+			t.Fatalf("%s %s -> handler %q, want %q", tc.method, tc.path, hit, tc.want)
+		}
+	}
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,39 @@
+# Dependencies
+/node_modules
+
+# Build output
+/dist
+/tmp
+/out-tsc
+/bazel-out
+
+# Angular cache
+/.angular/cache
+
+# Misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# IDE
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# System
+.DS_Store
+Thumbs.db

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -260,6 +260,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-16.1.7.tgz",
       "integrity": "sha512-+fMLwUlHLNsHWzX2cnsr4sMyix0R5v/a5srQTQjl6BYhdyqFgT82h5F4P49yFu+nZr0jdsxF012wPJbDRR+1qQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -274,6 +275,7 @@
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.1.6.tgz",
       "integrity": "sha512-ICwX3OyxmVotlhzlkvilvfZz32y9RXvUAaVtPsU1i20orgQBOMp+JGdP/vahLjTQRioUus834Wh6bu0KdHjCEg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -324,6 +326,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.1.7.tgz",
       "integrity": "sha512-7WwYwtJjuJtUkutB+aMCvtV5zxa43T4x+kqT+kS4KnUmLv5KdrGPxcS+/7YUuKEELWp1SG032UTwGPX0DXxH4g==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -339,6 +342,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.7.tgz",
       "integrity": "sha512-93nbMFPSpKNfUyuRvEQxPdYLU6g25oZ4Gp7ewzNLyDHIbTQv6FwsthHfgPigPJJUUyKak6Gr3koFsgk7Dl3LAA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -359,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.7.tgz",
       "integrity": "sha512-6iuogfVrbCh6o4hWbNCClsLQdLtlXiaNc72LGz5LMXI0TOwKVlRXhbzhiQeLS0/nsYIdHFbgyr1aepI2wQA3mQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.22.5",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -386,6 +391,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.1.7.tgz",
       "integrity": "sha512-Wl5BR9X1xnV7Z9v/MNVANhymuTKAuRv4etr4rRgaC5NbbJSuFM4y+mg4yVI4wmrYJo0gKRcV9+2mHaePr41fTg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -401,6 +407,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-16.1.7.tgz",
       "integrity": "sha512-AZ6oCIAS2JwH7rJiTOj2uKl1eykiDP98y0trgQ/42+zzpOQZyZAjXrtdqHkVUXMc1PFf5NmYioz19Muj1p+Ttg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -418,6 +425,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.1.7.tgz",
       "integrity": "sha512-AjdUUv5+v50cclHPsKVVdNRdCQZJMGNKmvxyLgeGj2hs61lGoJxBYcYqPre2PpM0SvezNJBreUvjwqM3ttOjng==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -456,6 +464,7 @@
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-16.1.7.tgz",
       "integrity": "sha512-nzjuAEAXLktA3puvSae54noAHEiuizNTvaOpuvQYHfvZF27QMW28XlC33+vDhckWjSD02K7Fb2+AELkOJhUM5Q==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -524,6 +533,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
       "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -3571,6 +3581,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3658,6 +3669,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4097,6 +4109,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -6963,7 +6976,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.0.tgz",
       "integrity": "sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -7096,6 +7110,7 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.2.tgz",
       "integrity": "sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -7194,6 +7209,7 @@
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -7358,6 +7374,7 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
       "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -9019,6 +9036,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -9686,6 +9704,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9721,6 +9740,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.2.tgz",
       "integrity": "sha512-u56TU0AIFqMtauKl/OJ1AeFsXqRHkgO7nCWmHaDwfxDo9GUMSqBA4NEh6GMuh1CYVM7zuROYtZrHzPc2ixK+ww==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -10557,6 +10577,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
       "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -10609,6 +10630,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10833,6 +10855,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11041,6 +11064,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
       "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.17.5",
         "postcss": "^8.4.23",
@@ -11129,6 +11153,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.86.0.tgz",
       "integrity": "sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -11204,6 +11229,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.0.tgz",
       "integrity": "sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -11350,6 +11376,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -16,6 +16,14 @@ const routes: Routes = [
       import("./pages/home/home.module").then((m) => m.HomeModule),
     canActivate: [authGuard],
   },
+  {
+    path: "control-center",
+    loadChildren: () =>
+      import("./pages/control-center/control-center.module").then(
+        (m) => m.ControlCenterModule
+      ),
+    canActivate: [authGuard],
+  },
   // {
   //   path: 'home',
   //   loadChildren: () =>

--- a/frontend/src/app/models/automation.model.interface.ts
+++ b/frontend/src/app/models/automation.model.interface.ts
@@ -32,8 +32,10 @@ export interface IAutomationModel {
 }
 
 export interface IAutomationHealthSummary {
+  total: number;
   healthy: number;
   warning: number;
+  degraded: number;
   broken: number;
   unknown: number;
   checkedAt: string;
@@ -48,6 +50,18 @@ export interface IAutomationHealthResult {
   consecutiveFailures: number;
 }
 
+export interface IAutomationHealthEvent {
+  id?: string;
+  automationId: string;
+  status: string;
+  checkType: string;
+  target?: string;
+  latencyMs: number;
+  failureReason?: string;
+  consecutiveFailures: number;
+  checkedAt: string;
+}
+
 export interface IAutomationDiagnostics {
   automationId: string;
   name: string;
@@ -57,5 +71,10 @@ export interface IAutomationDiagnostics {
   routePath: string;
   host: string;
   port: number;
+  lastCheckedAt?: string;
+  lastSuccessAt?: string;
+  lastFailureAt?: string;
+  lastFailureReason?: string;
   checks: Record<string, string>;
+  recentEvents: IAutomationHealthEvent[];
 }

--- a/frontend/src/app/pages/control-center/control-center.component.html
+++ b/frontend/src/app/pages/control-center/control-center.component.html
@@ -1,0 +1,197 @@
+<section>
+  <nz-layout>
+    <nz-header class="header-container">
+      <div class="header-content">
+        <h1 class="header-content__title">Control Center</h1>
+        <div class="header-content__actions">
+          <button nz-button nzType="default" (click)="refresh()" [nzLoading]="loading">
+            <i nz-icon nzType="reload" nzTheme="outline"></i>
+            Refresh
+          </button>
+          <button nz-button nzType="default" (click)="goHome()">
+            <i nz-icon nzType="appstore" nzTheme="outline"></i>
+            Automations
+          </button>
+        </div>
+      </div>
+    </nz-header>
+
+    <nz-content class="content-container">
+      <!-- Summary bar -->
+      <div nz-row [nzGutter]="16" class="summary-bar" *ngIf="summary as s">
+        <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="4">
+          <nz-card nzSize="small" class="summary-card">
+            <div class="summary-card__value">{{ s.total }}</div>
+            <div class="summary-card__label">Total</div>
+          </nz-card>
+        </div>
+        <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="4">
+          <nz-card nzSize="small" class="summary-card summary-card--healthy">
+            <div class="summary-card__value">{{ s.healthy }}</div>
+            <div class="summary-card__label">Healthy</div>
+          </nz-card>
+        </div>
+        <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="4">
+          <nz-card nzSize="small" class="summary-card summary-card--warning">
+            <div class="summary-card__value">{{ s.warning }}</div>
+            <div class="summary-card__label">Warning</div>
+          </nz-card>
+        </div>
+        <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="4">
+          <nz-card nzSize="small" class="summary-card summary-card--degraded">
+            <div class="summary-card__value">{{ s.degraded }}</div>
+            <div class="summary-card__label">Degraded</div>
+          </nz-card>
+        </div>
+        <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="4">
+          <nz-card nzSize="small" class="summary-card summary-card--broken">
+            <div class="summary-card__value">{{ s.broken }}</div>
+            <div class="summary-card__label">Broken</div>
+          </nz-card>
+        </div>
+        <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="4">
+          <nz-card nzSize="small" class="summary-card summary-card--unknown">
+            <div class="summary-card__value">{{ s.unknown }}</div>
+            <div class="summary-card__label">Unknown</div>
+          </nz-card>
+        </div>
+      </div>
+
+      <!-- Automations table -->
+      <nz-table
+        #table
+        [nzData]="automations"
+        [nzLoading]="loading"
+        [nzPageSize]="20"
+        nzSize="middle"
+        class="automation-table"
+      >
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Last checked</th>
+            <th>Last success</th>
+            <th>Last failure</th>
+            <th>Failure reason</th>
+            <th nzWidth="260px">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let automation of table.data">
+            <td>{{ automation.name }}</td>
+            <td>
+              <nz-tag [nzColor]="statusColor(automation.status)">
+                {{ automation.status || 'unknown' }}
+              </nz-tag>
+            </td>
+            <td>
+              {{ automation.lastCheckedAt ? (automation.lastCheckedAt | date: 'short') : '—' }}
+            </td>
+            <td>
+              {{ automation.lastSuccessAt ? (automation.lastSuccessAt | date: 'short') : '—' }}
+            </td>
+            <td>
+              {{ automation.lastFailureAt ? (automation.lastFailureAt | date: 'short') : '—' }}
+            </td>
+            <td class="reason-cell">
+              <span nz-tooltip [nzTooltipTitle]="automation.lastFailureReason || ''">
+                {{ automation.lastFailureReason || '—' }}
+              </span>
+            </td>
+            <td>
+              <button
+                nz-button
+                nzType="primary"
+                nzSize="small"
+                (click)="runHealthCheck(automation)"
+                [nzLoading]="isChecking(automation)"
+              >
+                Run Check
+              </button>
+              <button
+                nz-button
+                nzType="default"
+                nzSize="small"
+                (click)="openDiagnostics(automation)"
+              >
+                Diagnostics
+              </button>
+              <button
+                nz-button
+                nzType="link"
+                nzSize="small"
+                (click)="openTarget(automation)"
+                [disabled]="!isOpenable(automation)"
+                nz-tooltip
+                [nzTooltipTitle]="isOpenable(automation) ? targetUrl(automation) : 'No browser-openable URL'"
+              >
+                <i nz-icon nzType="link" nzTheme="outline"></i>
+                Open
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </nz-table>
+    </nz-content>
+  </nz-layout>
+</section>
+
+<!-- Diagnostics modal -->
+<nz-modal
+  [(nzVisible)]="isDiagnosticsVisible"
+  [nzTitle]="'Diagnostics — ' + diagnosticsName"
+  [nzFooter]="null"
+  (nzOnCancel)="closeDiagnostics()"
+  nzWidth="640px"
+>
+  <ng-container *nzModalContent>
+    <nz-spin [nzSpinning]="diagnosticsLoading">
+      <div *ngIf="diagnostics as d">
+        <p><strong>Status:</strong>
+          <nz-tag [nzColor]="statusColor(d.status)">{{ d.status || 'unknown' }}</nz-tag>
+        </p>
+        <p><strong>Launch target:</strong> {{ d.launchTarget || '—' }}</p>
+        <p><strong>Health check target:</strong> {{ d.healthCheckTarget || '—' }}</p>
+        <p><strong>Route path:</strong> {{ d.routePath || '—' }}</p>
+        <p><strong>Host / Port:</strong> {{ d.host || '—' }} : {{ d.port || '—' }}</p>
+        <p *ngIf="d.lastFailureReason"><strong>Last failure reason:</strong> {{ d.lastFailureReason }}</p>
+
+        <nz-divider nzText="Configuration checks" nzOrientation="left"></nz-divider>
+        <div class="checks-grid">
+          <div class="checks-grid__item" *ngFor="let key of diagnosticsCheckKeys()">
+            <span class="checks-grid__key">{{ key }}</span>
+            <nz-tag [nzColor]="d.checks[key] === 'ok' ? 'green' : 'red'">
+              {{ d.checks[key] }}
+            </nz-tag>
+          </div>
+        </div>
+
+        <nz-divider nzText="Recent health events" nzOrientation="left"></nz-divider>
+        <p *ngIf="!d.recentEvents?.length" class="muted">No health history recorded yet.</p>
+        <table class="events-table" *ngIf="d.recentEvents?.length">
+          <thead>
+            <tr>
+              <th>Checked at</th>
+              <th>Status</th>
+              <th>Type</th>
+              <th>Latency</th>
+              <th>Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let event of d.recentEvents">
+              <td>{{ event.checkedAt | date: 'short' }}</td>
+              <td>
+                <nz-tag [nzColor]="statusColor(event.status)">{{ event.status }}</nz-tag>
+              </td>
+              <td>{{ event.checkType }}</td>
+              <td>{{ event.latencyMs }} ms</td>
+              <td class="reason-cell">{{ event.failureReason || '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </nz-spin>
+  </ng-container>
+</nz-modal>

--- a/frontend/src/app/pages/control-center/control-center.component.scss
+++ b/frontend/src/app/pages/control-center/control-center.component.scss
@@ -1,0 +1,114 @@
+.header-container {
+  background: #001529;
+  padding: 0 24px;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  &__title {
+    color: #fff;
+    margin: 0;
+    font-size: 20px;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.content-container {
+  padding: 24px;
+  background: #f0f2f5;
+  min-height: calc(100vh - 64px);
+}
+
+.summary-bar {
+  margin-bottom: 24px;
+}
+
+.summary-card {
+  text-align: center;
+
+  &__value {
+    font-size: 26px;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  &__label {
+    color: rgba(0, 0, 0, 0.45);
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 0.5px;
+  }
+
+  &--healthy &__value {
+    color: #52c41a;
+  }
+  &--warning &__value {
+    color: #faad14;
+  }
+  &--degraded &__value {
+    color: #fa8c16;
+  }
+  &--broken &__value {
+    color: #f5222d;
+  }
+  &--unknown &__value {
+    color: rgba(0, 0, 0, 0.45);
+  }
+}
+
+.automation-table {
+  background: #fff;
+}
+
+.reason-cell {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.checks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__key {
+    font-size: 13px;
+    color: rgba(0, 0, 0, 0.65);
+  }
+}
+
+.events-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  th,
+  td {
+    text-align: left;
+    padding: 6px 8px;
+    border-bottom: 1px solid #f0f0f0;
+  }
+
+  th {
+    color: rgba(0, 0, 0, 0.45);
+    font-weight: 500;
+  }
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.45);
+}

--- a/frontend/src/app/pages/control-center/control-center.component.ts
+++ b/frontend/src/app/pages/control-center/control-center.component.ts
@@ -156,7 +156,7 @@ export class ControlCenterComponent implements OnInit {
       case 'broken':
         return 'red'
       default:
-        return 'default'
+        return ''
     }
   }
 

--- a/frontend/src/app/pages/control-center/control-center.component.ts
+++ b/frontend/src/app/pages/control-center/control-center.component.ts
@@ -1,0 +1,170 @@
+import { Component, Inject, OnInit } from '@angular/core'
+import { Router } from '@angular/router'
+import { NzNotificationService } from 'ng-zorro-antd/notification'
+import { AUTOMATIONS_SERVICE_TOKEN } from '../../services/automations/automations.service.token'
+import { IAutomationsService } from '../../services/automations.service.interface'
+import {
+  IAutomationDiagnostics,
+  IAutomationHealthSummary,
+  IAutomationModel,
+} from '../../models/automation.model.interface'
+
+@Component({
+  selector: 'app-control-center',
+  templateUrl: './control-center.component.html',
+  styleUrls: ['./control-center.component.scss'],
+})
+export class ControlCenterComponent implements OnInit {
+  automations: IAutomationModel[] = []
+  summary?: IAutomationHealthSummary
+  loading = false
+  private checkingIds = new Set<string>()
+
+  isDiagnosticsVisible = false
+  diagnostics?: IAutomationDiagnostics
+  diagnosticsLoading = false
+  diagnosticsName = ''
+
+  constructor(
+    @Inject(AUTOMATIONS_SERVICE_TOKEN)
+    private automationsService: IAutomationsService,
+    private notification: NzNotificationService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.refresh()
+  }
+
+  refresh(): void {
+    this.loading = true
+    this.automationsService.getAutomations().subscribe({
+      next: (automations) => {
+        this.automations = automations.sort((a, b) => a.position - b.position)
+        this.loading = false
+      },
+      error: () => {
+        this.loading = false
+        this.notification.error('Error', 'Failed to load automations.')
+      },
+    })
+    this.loadSummary()
+  }
+
+  loadSummary(): void {
+    this.automationsService.getHealthSummary().subscribe({
+      next: (summary) => (this.summary = summary),
+      error: () =>
+        this.notification.error('Error', 'Failed to load health summary.'),
+    })
+  }
+
+  runHealthCheck(automation: IAutomationModel): void {
+    if (!automation.id) {
+      return
+    }
+    const id = automation.id
+    this.checkingIds.add(id)
+    this.automationsService.runHealthCheck(id).subscribe({
+      next: (result) => {
+        this.checkingIds.delete(id)
+        automation.status = result.status
+        automation.lastCheckedAt = result.checkedAt
+        automation.averageLatencyMs = result.latencyMs
+        automation.consecutiveFailures = result.consecutiveFailures
+        if (result.status === 'healthy') {
+          automation.lastSuccessAt = result.checkedAt
+          automation.lastFailureReason = ''
+        } else if (result.failureReason) {
+          automation.lastFailureAt = result.checkedAt
+          automation.lastFailureReason = result.failureReason
+        }
+        this.loadSummary()
+        this.notification.success(
+          'Health check',
+          `${automation.name}: ${result.status}`
+        )
+      },
+      error: () => {
+        this.checkingIds.delete(id)
+        this.notification.error(
+          'Error',
+          `Health check failed for ${automation.name}.`
+        )
+      },
+    })
+  }
+
+  isChecking(automation: IAutomationModel): boolean {
+    return !!automation.id && this.checkingIds.has(automation.id)
+  }
+
+  openDiagnostics(automation: IAutomationModel): void {
+    if (!automation.id) {
+      return
+    }
+    this.isDiagnosticsVisible = true
+    this.diagnosticsLoading = true
+    this.diagnostics = undefined
+    this.diagnosticsName = automation.name
+    this.automationsService.getDiagnostics(automation.id).subscribe({
+      next: (diagnostics) => {
+        this.diagnostics = diagnostics
+        this.diagnosticsLoading = false
+      },
+      error: () => {
+        this.diagnosticsLoading = false
+        this.notification.error('Error', 'Failed to load diagnostics.')
+      },
+    })
+  }
+
+  closeDiagnostics(): void {
+    this.isDiagnosticsVisible = false
+    this.diagnostics = undefined
+  }
+
+  openTarget(automation: IAutomationModel): void {
+    const url = this.targetUrl(automation)
+    if (url) {
+      window.open(url, '_blank', 'noopener')
+    }
+  }
+
+  targetUrl(automation: IAutomationModel): string {
+    return (
+      automation.launchTarget ||
+      automation.publicUrl ||
+      automation.localUrl ||
+      automation.healthCheckUrl ||
+      ''
+    )
+  }
+
+  isOpenable(automation: IAutomationModel): boolean {
+    return /^https?:\/\//i.test(this.targetUrl(automation))
+  }
+
+  statusColor(status?: string): string {
+    switch ((status || 'unknown').toLowerCase()) {
+      case 'healthy':
+        return 'green'
+      case 'warning':
+        return 'gold'
+      case 'degraded':
+        return 'orange'
+      case 'broken':
+        return 'red'
+      default:
+        return 'default'
+    }
+  }
+
+  diagnosticsCheckKeys(): string[] {
+    return this.diagnostics ? Object.keys(this.diagnostics.checks) : []
+  }
+
+  goHome(): void {
+    this.router.navigate(['/home'])
+  }
+}

--- a/frontend/src/app/pages/control-center/control-center.module.ts
+++ b/frontend/src/app/pages/control-center/control-center.module.ts
@@ -1,0 +1,44 @@
+import { NgModule } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { RouterModule, Routes } from '@angular/router'
+import { FormsModule } from '@angular/forms'
+import { NzLayoutModule } from 'ng-zorro-antd/layout'
+import { NzTableModule } from 'ng-zorro-antd/table'
+import { NzTagModule } from 'ng-zorro-antd/tag'
+import { NzButtonModule } from 'ng-zorro-antd/button'
+import { NzIconModule } from 'ng-zorro-antd/icon'
+import { NzCardModule } from 'ng-zorro-antd/card'
+import { NzModalModule } from 'ng-zorro-antd/modal'
+import { NzGridModule } from 'ng-zorro-antd/grid'
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
+import { NzSpinModule } from 'ng-zorro-antd/spin'
+import { NzDividerModule } from 'ng-zorro-antd/divider'
+import { ControlCenterComponent } from './control-center.component'
+import { AUTOMATIONS_SERVICE_TOKEN } from '../../services/automations/automations.service.token'
+import { AutomationsService } from '../../services/automations/automations.service'
+
+const routes: Routes = [{ path: '', component: ControlCenterComponent }]
+
+@NgModule({
+  declarations: [ControlCenterComponent],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    FormsModule,
+    NzLayoutModule,
+    NzTableModule,
+    NzTagModule,
+    NzButtonModule,
+    NzIconModule,
+    NzCardModule,
+    NzModalModule,
+    NzGridModule,
+    NzToolTipModule,
+    NzSpinModule,
+    NzDividerModule,
+  ],
+  providers: [
+    { provide: AUTOMATIONS_SERVICE_TOKEN, useClass: AutomationsService },
+  ],
+})
+export class ControlCenterModule {}

--- a/frontend/src/app/pages/home/home.component.html
+++ b/frontend/src/app/pages/home/home.component.html
@@ -32,6 +32,15 @@
               ></i>
               Add Automation
             </li>
+            <li nz-menu-item routerLink="/control-center">
+              <i
+                class="menu-item__icon"
+                nz-icon
+                nzType="dashboard"
+                nzTheme="outline"
+              ></i>
+              Control Center
+            </li>
             <li nz-menu-item (click)="logout()">
               <i
                 class="menu-item__icon"

--- a/frontend/src/app/services/automations/automations.service.ts
+++ b/frontend/src/app/services/automations/automations.service.ts
@@ -1,6 +1,11 @@
 import {Injectable} from '@angular/core';
 import {IAutomationsService} from '../automations.service.interface';
-import {IAutomationModel} from "../../models/automation.model.interface";
+import {
+  IAutomationDiagnostics,
+  IAutomationHealthResult,
+  IAutomationHealthSummary,
+  IAutomationModel,
+} from "../../models/automation.model.interface";
 import {Observable} from "rxjs";
 import {HttpClient} from "@angular/common/http";
 
@@ -54,6 +59,18 @@ export class AutomationsService implements IAutomationsService {
 
   swapAutomations(automation_id1: string, automation_id2: string): Observable<void> {
     return this.http.get<void>(`${this.apiUrl}/swap/${automation_id1}/${automation_id2}`);
+  }
+
+  getHealthSummary(): Observable<IAutomationHealthSummary> {
+    return this.http.get<IAutomationHealthSummary>(`${this.apiUrl}/health/summary`);
+  }
+
+  runHealthCheck(id: string): Observable<IAutomationHealthResult> {
+    return this.http.post<IAutomationHealthResult>(`${this.apiUrl}/${id}/health-check`, {});
+  }
+
+  getDiagnostics(id: string): Observable<IAutomationDiagnostics> {
+    return this.http.get<IAutomationDiagnostics>(`${this.apiUrl}/${id}/diagnostics`);
   }
 
 }


### PR DESCRIPTION
Completes the integration work for the Automation Control Center on top of the existing monitoring foundation.

## Backend
- Include the operational models (health events, dependencies, route checks, alerts, incidents, SLOs) in `AutoMigrate`, and ensure the `uuid-ossp` extension on startup.
- Register the three routes:
  - `GET  /api/v1/automation/health/summary`
  - `POST /api/v1/automation/:id/health-check`
  - `GET  /api/v1/automation/:id/diagnostics`
- HTTP/TCP health checks store their result on the automation and now also persist an `AutomationHealthEvent` (history). Diagnostics returns the last checked/success/failure details plus the 10 most recent events. The summary reports total/healthy/warning/degraded/broken/unknown.

## Frontend
- Add `getHealthSummary`, `runHealthCheck` and `getDiagnostics` to the automations service.
- New Control Center page: summary bar, automation table with status badges (healthy/warning/degraded/broken/unknown), last checked/success/failure, failure reason, a manual **Run Check** button, a browser-safe **Open** link, and a diagnostics modal showing configuration checks and recent health events.
- Linked from the home menu at `/control-center`.

## Safety
No arbitrary command execution. Health checks are HTTP/TCP probes only; opening a target uses `window.open` with `noopener`. Local runner / service control is left out of scope as noted in the blueprint.

## Testing
- Backend: `cd backend && go build ./...` — compiles.
- Frontend: `cd frontend && npm install && npm run build` — compiles (Control Center builds as its own lazy chunk).
- See the README "Automation Control Center" section for API smoke tests and end-to-end steps.